### PR TITLE
Workaround for new style netflix using ratewizard (issue #2)

### DIFF
--- a/netflix-rater/account.json
+++ b/netflix-rater/account.json
@@ -1,0 +1,1 @@
+[{"accountid":".. ..","authkey":" .. .." }]

--- a/netflix-rater/background.js
+++ b/netflix-rater/background.js
@@ -1,33 +1,56 @@
-// Load data file
+// Load data file with ratings
 var ratings;
 var xhr = new XMLHttpRequest();
+
 xhr.onreadystatechange = function() {
 	if (xhr.readyState == 4) {
+		//alert(xhr.responseText);
 		ratings = JSON.parse(xhr.responseText);
+		console.log('Got the file!');
+		//alert("ratings: "+ ratings);
 	}
 }
 xhr.open("GET", chrome.extension.getURL('/netflix.json'), true);
+//alert(chrome.extension.getURL('/netflix.json'));
 xhr.send();
+
+
+// Load account details
+var authKey;// 
+var accountID;// 
+var xhr2 = new XMLHttpRequest();
+
+xhr2.onreadystatechange = function() {
+	if (xhr2.readyState == 4) {
+		//alert(xhr.responseText);
+		resp = JSON.parse(xhr2.responseText);
+		console.log(resp);
+		response = resp.shift();
+		console.log(response);
+		accountID = response.accountid;
+		authKey = response.authkey;	
+		console.log(authKey + ' '+ accountID);
+		//alert("ratings: "+ ratings);
+	}
+}
+xhr2.open("GET", chrome.extenssion.getURL('/account.json'), true);
+xhr2.send();
+
 
 // This is what does the work for a given movie
 var tabIds = [];
 function rate(movie) {
-	var starClass;
-	if (movie.rating == 0) {
-		starClass = "rvnorec";
-	} else {
-		starClass = "rv" + movie.rating;
-	}
-	console.log(movie.url + " " + starClass);
-	chrome.tabs.create({"url": movie.url, "active": false}, function(tab) {
-		console.log("Opened " + tab.id);
+	//Create url
+	url = "http://www.netflix.com/SetRating?value="+movie.rating+"&widgetid=M"+movie.id+"_"+accountID+"&rtrnct=true&authURL="+authKey;
+	
+	chrome.tabs.create({"url": url, "active": false}, function(tab) {
+		console.log("Opened " + tab.id+ "| "+ url);
 		tabIds.push(tab.id);
 		if (tabIds.length > 10) {
 			var tabId = tabIds.shift();
 			console.log("Removing " + tabId);
 			chrome.tabs.remove(tabId);
 		}
-		chrome.tabs.executeScript(tab.id, {"code": "var star = document.getElementsByClassName('" + starClass + "')[0]; star.click();"});
 	});
 }
 
@@ -36,5 +59,6 @@ var intervalId;
 chrome.browserAction.onClicked.addListener(function() {
 	// Try to rate each movie every 5 seconds
 	clearInterval(intervalId);
+	console.log("hello!");
 	intervalId = setInterval(function() { rate(ratings.shift())}, 5000);
 });


### PR DESCRIPTION
Using the ratingswizard, only a URL with get-requests is needed to
import a rating.

Now, you need a file called 'account.json' , in which the accountid and
authentication url are put. These can be found on
http://www.netflix.com/RatingsWizard?skgr=false&wizst=2, by copying the
link address from one the rating stars (any).
The URL looks like this
http://www.netflix.com/SetRating?value=4&pval=4.0626845&widgetid=M70001989_XXXXXXXXXX&rtrnct=true&authURL=YYYYYYYYYYYYYYYYYYYYYYYYY&section=RECS

XXXX refers to the account id (you can skip anything from _
(underscore), if present.
YYYYYYY refers to the authentication url
